### PR TITLE
Update diagrampage.py

### DIFF
--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -134,6 +134,7 @@ class DiagramPage:
         view.connect("selection-changed", self._on_view_selection_changed)
         view.connect_after("key-press-event", self._on_key_press_event)
         view.connect("drag-data-received", self._on_drag_data_received)
+        view.connect("scroll-event", self.on_scroll)
 
         self.view = view
 
@@ -303,6 +304,14 @@ class DiagramPage:
         view.bounding_box_painter = BoundingBoxPainter(item_painter)
 
         view.queue_draw_refresh()
+
+    def on_scroll(self, btn, event):
+        """Handle the mouse wheel to zoom in and out"""
+        if event.direction == Gdk.ScrollDirection.UP:
+            self.zoom_in()
+        elif event.direction == Gdk.ScrollDirection.DOWN:
+            self.zoom_out()
+        return True 
 
     def _on_key_press_event(self, view, event):
         """Handle the 'Delete' key.


### PR DESCRIPTION
Adding zoom in and out wit the mouse wheel

Using the mouse wheel for zooming in and out of an editor window is very common and makes it easier to work than having to click buttons for that purpose.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [x ] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
A new feature for editing a diagram.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
Currently one has to click on two tiny buttons to zoom in and out, having to move away from the editing area.

Issue Number: N/A

### What is the new behavior?
This feature makes zooming easier by just using the mouse wheel.

### Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
